### PR TITLE
Always install bundler with redmine installer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ gemspec
 gem 'pry'
 gem 'rspec'
 gem 'childprocess'
+gem 'bundler'
+
+


### PR DESCRIPTION
We need bundler to be ready everytime when we use redmine-installer.