### PR TITLE
DEPRECATED call fix

### DIFF
--- a/lib/redmine-installer/command.rb
+++ b/lib/redmine-installer/command.rb
@@ -13,7 +13,7 @@ module RedmineInstaller
     end
 
     def run
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         run!
       end
     end

--- a/lib/redmine-installer/easycheck.rb
+++ b/lib/redmine-installer/easycheck.rb
@@ -7,7 +7,7 @@ module RedmineInstaller
     EASYCHECK_SH = 'https://raw.githubusercontent.com/easyredmine/easy_server_requirements_check/master/easycheck.sh'
 
     def self.run
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         if Kernel.system('which', 'wget')
           Open3.pipeline(['wget', EASYCHECK_SH, '-O', '-', '--quiet'], 'bash')
 


### PR DESCRIPTION
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /var/lib/gems/2.5.0/gems/redmine-installer-2.3.2/lib/redmine-installer/easycheck.rb:10)