### PR TITLE
allow the administrator to manually empty the root directory

### DIFF
--- a/lib/redmine-installer/redmine.rb
+++ b/lib/redmine-installer/redmine.rb
@@ -1,4 +1,5 @@
 require 'find'
+require 'io/console'
 
 module RedmineInstaller
   class Redmine < TaskModule
@@ -279,7 +280,17 @@ module RedmineInstaller
           next if entry == '.' || entry == '..'
           next if entry == FILES_DIR && task.options.copy_files_with_symlink
 
-          FileUtils.remove_entry_secure(entry)
+          begin
+            FileUtils.remove_entry_secure(entry)
+          rescue
+            if task.options.copy_files_with_symlink
+              print_title('Cannot automatically empty ' + root + '. Please manually empty this directory (except for ' + root + '/' + FILES_DIR + ') and then hit any key to continue...')
+            else
+              print_title('Cannot automatically empty ' + root + '. Please manually empty this directory and then hit any key to continue...')
+            end
+            STDIN.getch
+            break
+          end
         end
       end
 


### PR DESCRIPTION
I have run into this problem several times now where something will holding open a file in the redmine root directory while the installer is running. This causes the installer to fail at the very last step, and the new redmine file tree that is being created in `/tmp` is lost. This enhancement prints a message to the screen so the administrator can intervene, manually resolve the problem and finish emptying the redmine root directory, and then continue past the error. The following demonstrates how this functionality works:


Normal behavior:
```
# redmine upgrade /path/to/redmine-package.zip
Executing after install script no. 1/2...
Executing after install script no. 2/2...
All after install scripts executed.
Done.
Done.

Finishing installation
Cleaning root ...
Cannot automatically empty /path/to/redmine. Please manually empty this directory and then hit any key to continue...
OK
Moving redmine to target directory ... OK
Cleanning up ... OK
Moving installer log ... OK

Redmine was upgraded
Do you want save steps for further use? No
```

Behavior when `--copy-files-with-symlink` is used:
```
# redmine upgrade --copy-files-with-symlink /path/to/redmine-package.zip
Executing after install script no. 1/2...
Executing after install script no. 2/2...
All after install scripts executed.
Done.
Done.

Finishing installation
Cleaning root ...
Cannot automatically empty /path/to/redmine. Please manually empty this directory (except for /path/to/redmine/files) and then hit any key to continue...
OK
Moving redmine to target directory ... OK
Cleanning up ... OK
Moving installer log ... OK

Redmine was upgraded
Do you want save steps for further use? No
```